### PR TITLE
NBConvert Now Used to Render IPYNB Files When Deploying Website

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -14,13 +14,39 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
-      - name: Install Dependencies
+      - name: Install Application Dependencies
+        run: |
+          sudo apt-get install parallel
+      - name: Install Python Dependencies
         run: |
           pip install -r requirements.txt
+      - name: Compile Jupyter Notebooks to Markdown
+        run: |
+          # Find all within the docs/ folder and subdirectories...
+          find ./docs \
+            # ...that are files...
+            -type f \
+            # ...with a .ipynb extension...
+            -name "*.ipynb" \
+            # ...and print the full path to each file to STDOUT,
+            # terminating each entry with a NULL character, piping
+            # the contents of STDOUT to STDIN of the next process.
+            -print0 | \
+          # For each entry received on STDIN...
+          parallel \
+            # ...where the entries are terminated with a NULL character...
+            -0 \
+            # ...display progress information for running and queued jobs...
+            --progress \
+            # ...stop immediately when one job fails...
+            --halt now,fail=1 \
+            # ...and run the following command in parallel for each
+            # file entry, substituting the path to the file for {}.
+            'jupyter nbconvert --to markdown {}'
       - name: Build Website
         run: |
           mkdocs build
-      - name: Push Build Website to gh-pages Branch
+      - name: Push Built Website to gh-pages Branch
         run: |
           git config --global user.name 'Hongnan G.'
           git config --global user.email 'ghnreigns@users.noreply.github.com'

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ site/
 venv_ml_website
 **/.ipynb_checkpoints/
 
+# Converted Markdown Files
+docs/*/**/*.md
+
 # MacOS
 .DS_Store
 */.DS_Store

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,15 +24,15 @@ nav:
       - Classification:
         - Projects:
           - Breast Cancer Wisconsin:
-            - Introduction: supervised_learning/classification/breast_cancer_wisconsin/Stage 0 - Introduction and Problem Statement.ipynb
-            - Preliminary Data Inspection and Cleaning: supervised_learning/classification/breast_cancer_wisconsin/Stage 1 - Preliminary Data Inspection and Cleaning.ipynb
-            - EDA: supervised_learning/classification/breast_cancer_wisconsin/Stage 2 - Preliminary EDA.ipynb
-            - Feature Engineering: supervised_learning/classification/breast_cancer_wisconsin/Stage 3 - Feature Engineering.ipynb
-            - Modelling (Metrics): supervised_learning/classification/breast_cancer_wisconsin/Stage 4 - Modelling (Metric to Optimize).ipynb
-            - Modelling (Cross-Validation Schema): supervised_learning/classification/breast_cancer_wisconsin/Stage 5 - Modelling (Cross-Validation Methodology).ipynb
-            - Modelling (Preprocessing and Spot Checking): supervised_learning/classification/breast_cancer_wisconsin/Stage 6 - Modelling (Preprocessing and Spot Checking).ipynb
-            - Modelling (Model Selection): supervised_learning/classification/breast_cancer_wisconsin/Stage 7 - Modelling (Model Selection and Hyperparameter Tuning).ipynb
-            - Modelling (Model Evaluation): supervised_learning/classification/breast_cancer_wisconsin/Stage 8 - Modelling (Model Evaluation and Interpretation).ipynb
+            - Introduction: supervised_learning/classification/breast_cancer_wisconsin/Stage 0 - Introduction and Problem Statement.md
+            - Preliminary Data Inspection and Cleaning: supervised_learning/classification/breast_cancer_wisconsin/Stage 1 - Preliminary Data Inspection and Cleaning.md
+            - EDA: supervised_learning/classification/breast_cancer_wisconsin/Stage 2 - Preliminary EDA.md
+            - Feature Engineering: supervised_learning/classification/breast_cancer_wisconsin/Stage 3 - Feature Engineering.md
+            - Modelling (Metrics): supervised_learning/classification/breast_cancer_wisconsin/Stage 4 - Modelling (Metric to Optimize).md
+            - Modelling (Cross-Validation Schema): supervised_learning/classification/breast_cancer_wisconsin/Stage 5 - Modelling (Cross-Validation Methodology).md
+            - Modelling (Preprocessing and Spot Checking): supervised_learning/classification/breast_cancer_wisconsin/Stage 6 - Modelling (Preprocessing and Spot Checking).md
+            - Modelling (Model Selection): supervised_learning/classification/breast_cancer_wisconsin/Stage 7 - Modelling (Model Selection and Hyperparameter Tuning).md
+            - Modelling (Model Evaluation): supervised_learning/classification/breast_cancer_wisconsin/Stage 8 - Modelling (Model Evaluation and Interpretation).md
   - Deep Learning with PyTorch:
     - Computer Vision:
       - Image: deep_learning/computer_vision/image.md
@@ -48,11 +48,6 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.arithmatex:
       generic: true
-plugins:
-  - mkdocs-jupyter:
-      execute: False
-      ignore_h1_titles: True
-      kernel_name: python3
 extra_javascript:
   - javascript/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 mkdocs==1.2.3
 mkdocs-material==7.3.5
 ghp-import==2.0.2
-mkdocs-jupyter==0.18.0
 ipykernel
 scikit-learn==1.0.1
 numpy==1.21.4
 pandas==1.3.4
+nbconvert==6.3.0
 jupyterlab-git


### PR DESCRIPTION
This pull request updates the website deployment GitHub Actions workflow to use `nbconvert` to convert all Jupyter Notebooks to Markdown format before building the website with MkDocs. Please see the comments in the updated workflow file for an explanation of the conversion process.

After merging this pull request, all links in your website and in the `mkdocs.yml` `nav` section should be to Markdown files (i.e., `.md`) instead of to Notebook files (i.e., `.ipynb`). With the removal of the `mkdocs-jupyter` plugin, linking to a Jupyter Notebook file directly will cause a website reader to download the notebook file directly.